### PR TITLE
Fix abs in the Num instance of Frac

### DIFF
--- a/posts/2019-12-14-stern-brocot.markdown
+++ b/posts/2019-12-14-stern-brocot.markdown
@@ -112,7 +112,7 @@ instance Num Frac where
   (x :/ xd) * (y :/ yd) = (x * y) :/ (xd * yd)
   (x :/ xd) + (y :/ yd) = (x * yd + y * xd) :/ (xd * yd)
   signum = (:/ 1) . signum . numerator
-  abs = id
+  abs (x :/ xd) = abs x :/ xd
   (x :/ xd) - (y :/ yd) = (x * yd - y * xd) :/ (xd * yd)
 ```
 </details>


### PR DESCRIPTION
`abs x * signum x` is supposed to be the same as `x`. Make this the case, as well as making `abs` work as you'd expect for fractions in math.